### PR TITLE
Fix upload URL handling

### DIFF
--- a/src/axios/axios.js
+++ b/src/axios/axios.js
@@ -1,7 +1,8 @@
 import axios from 'axios';
 
+const API_URL = process.env.REACT_APP_API_URL || 'http://localhost:3001/api';
 const instance = axios.create({
-  baseURL: process.env.REACT_APP_API_URL || 'http://localhost:3001/api'
+  baseURL: API_URL
 });
 
 instance.interceptors.request.use((config) => {
@@ -9,4 +10,5 @@ instance.interceptors.request.use((config) => {
   return config;
 });
 
+export const API_ROOT = API_URL.replace(/\/api$/, '');
 export default instance;

--- a/src/components/adminPannel/post/edit.jsx
+++ b/src/components/adminPannel/post/edit.jsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useState } from "react"
-import axios from '../../../axios/axios'
+import axios, { API_ROOT } from '../../../axios/axios'
 import style from "./style.module.css"
 import { useEffect } from "react"
 import { useSelector } from "react-redux"
@@ -88,7 +88,7 @@ function EditPost() {
       formData.append('image', file)
       const { data } = await axios.post('/uploads', formData)
       console.log(data)
-      setImageUrl(`http://api.electrojor.ru${data.url}`)
+      setImageUrl(`${API_ROOT}${data.url}`)
     } catch (err) {
       console.warn(err)
       alert('Ошибка загрузки фото')
@@ -102,7 +102,7 @@ function EditPost() {
       formData.append('image', file)
       const { data } = await axios.post('/uploads', formData)
       console.log(data)
-      arrayTimes.push(`http://api.electrojor.ru${data.url}`)
+      arrayTimes.push(`${API_ROOT}${data.url}`)
       console.log(arrayTimes);
       setUpdate(true)
     } catch (err) {


### PR DESCRIPTION
## Summary
- add API_ROOT constant in axios instance
- use API_ROOT when constructing image URLs in post editor

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863fa59e6d48324af3f18122e6e1d67