### PR TITLE
Fix API URL handling for admin article creation

### DIFF
--- a/src/axios/axios.js
+++ b/src/axios/axios.js
@@ -1,6 +1,14 @@
 import axios from 'axios';
 
-const API_URL = process.env.REACT_APP_API_URL || 'http://localhost:3001/api';
+// Support both with and without the `/api` suffix in the environment variable.
+// `API_URL` should always point to the `/api` prefix while `API_ROOT` is the
+// host root used for serving static assets like uploaded images.
+const RAW_URL = process.env.REACT_APP_API_URL || 'http://localhost:3001/api';
+const API_URL = RAW_URL.endsWith('/api')
+  ? RAW_URL
+  : `${RAW_URL.replace(/\/$/, '')}/api`;
+const API_ROOT = API_URL.replace(/\/api$/, '');
+
 const instance = axios.create({
   baseURL: API_URL
 });
@@ -10,5 +18,5 @@ instance.interceptors.request.use((config) => {
   return config;
 });
 
-export const API_ROOT = API_URL.replace(/\/api$/, '');
+export { API_ROOT };
 export default instance;


### PR DESCRIPTION
## Summary
- ensure REACT_APP_API_URL works with or without the `/api` suffix

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863fbfe1ea48324a3c6ae8cebc8ce04