### PR TITLE
Add phone mask

### DIFF
--- a/src/components/callback/callBack3.jsx
+++ b/src/components/callback/callBack3.jsx
@@ -4,6 +4,7 @@ import RussianFlagIco from './img/flag.png'
 import styled from "./callback.module.css"
 import { Box } from "@mui/material"
 import { useForm } from "react-hook-form";
+import { maskPhoneInput } from "../../utils/phone";
 
 function CallBackBottom() {
     const { register, formState: { errors }, handleSubmit } = useForm();
@@ -54,13 +55,16 @@ function CallBackBottom() {
                                 </Text>
                                 <form onSubmit={handleSubmit(onSubmit)} className={styled.inputBlock}>
                                     <img src={RussianFlagIco} alt="" />
-                                    <input placeholder=" +7 (999) 999 99 99" type="text" className={styled.callbackInput} id="standard-basic" label="Телефон" variant="standard" {...register('phone', {
+                                    <input placeholder="+7 (___) ___-__-__" type="text" className={styled.callbackInput} id="standard-basic" label="Телефон" variant="standard" {...register('phone', {
                             required: "Заполните поле с номером телефона", pattern: {
-                                value: /\d+/,
+                                value: /\d+/, 
                                 message: "Это поле только для цыфр"
                             }, minLength: {
                                 value: 10,
                                 message: "Минимальное количество символов в номере телефона 10"
+                            },
+                            onChange: (e) => {
+                                e.target.value = maskPhoneInput(e.target.value);
                             },
                         })}
                             aria-invalid={errors.phone ? "true" : "false"}
@@ -115,18 +119,21 @@ function CallBackBottom() {
                     </Text>
                     <div className={styled.mobileInput}>
                         <img src={RussianFlagIco} alt="" />
-                        <input placeholder=" +7 (999) 999 99 99" type="text" style={{
+                        <input placeholder="+7 (___) ___-__-__" type="text" style={{
                             borderRadius: "6px",
                             border: "1px solid #2359C1",
                             background: "#FFF",
                             width: "160px"
                         }}id="standard-basic" label="Телефон" variant="standard" {...register('phone', {
                             required: "Заполните поле с номером телефона", pattern: {
-                                value: /\d+/,
+                                value: /\d+/, 
                                 message: "Это поле только для цыфр"
                             }, minLength: {
                                 value: 10,
                                 message: "Минимальное количество символов в номере телефона 10"
+                            },
+                            onChange: (e) => {
+                                e.target.value = maskPhoneInput(e.target.value);
                             },
                         })}
                             aria-invalid={errors.phone ? "true" : "false"}

--- a/src/components/callback/callback1.jsx
+++ b/src/components/callback/callback1.jsx
@@ -5,6 +5,7 @@ import FlagImg from "./img/flag.png"
 import pliers from "./img/pliers.png"
 import { Box } from "@mui/material"
 import { useForm } from "react-hook-form";
+import { maskPhoneInput } from "../../utils/phone";
 
 function CallBack1() {
     const { register, formState: { errors }, handleSubmit } = useForm();
@@ -99,13 +100,16 @@ function CallBack1() {
                     }}>
                     <img src={FlagImg} alt="qwe" />
                     </Box>
-                    <input placeholder=" +7 (999) 999 99 99" className={style.input} type="text" id="standard-basic" label="Телефон" variant="standard" {...register('phone', {
+                    <input placeholder="+7 (___) ___-__-__" className={style.input} type="text" id="standard-basic" label="Телефон" variant="standard" {...register('phone', {
                                 required: "Заполните поле с номером телефона", pattern: {
-                                    value: /\d+/,
+                                    value: /\d+/, 
                                     message: "Это поле только для цыфр"
                                 }, minLength: {
                                     value: 10,
                                     message: "Минимальное количество символов в номере телефона 10"
+                                },
+                                onChange: (e) => {
+                                    e.target.value = maskPhoneInput(e.target.value);
                                 },
                             })}
                                 aria-invalid={errors.phone ? "true" : "false"}

--- a/src/components/header/headerInfo.jsx
+++ b/src/components/header/headerInfo.jsx
@@ -15,7 +15,7 @@ import { useState } from "react";
 import { Link } from "react-router-dom";
 import logo from './logo.png';
 import { useSelector } from "react-redux";
-import { phoneDigits } from "../../utils/phone";
+import { phoneDigits, maskPhoneInput } from "../../utils/phone";
 
 function InfoHeader() {
     const { register, formState: { errors }, handleSubmit } = useForm();
@@ -167,6 +167,9 @@ function InfoHeader() {
                                             minLength: {
                                                 value: 10,
                                                 message: "Минимум 10 цифр"
+                                            },
+                                            onChange: (e) => {
+                                                e.target.value = maskPhoneInput(e.target.value);
                                             },
                                         })}
                                         aria-invalid={errors.phone ? "true" : "false"}

--- a/src/utils/phone.js
+++ b/src/utils/phone.js
@@ -4,5 +4,15 @@ export function phoneDigits(phone) {
 export function formatPhone(phone) {
   const digits = phoneDigits(phone);
   if (digits.length !== 11) return phone;
-  return `+${digits[0]}-${digits.slice(1,4)}-${digits.slice(4,7)}-${digits.slice(7,9)}-${digits.slice(9)}`;
+  return `+${digits[0]}-(${digits.slice(1,4)})-${digits.slice(4,7)}-${digits.slice(7,9)}-${digits.slice(9)}`;
+}
+
+export function maskPhoneInput(value) {
+  const digits = phoneDigits(value).slice(0, 11);
+  let result = "+7";
+  if (digits.length > 1) result += `-(${digits.slice(1, 4)}`;
+  if (digits.length >= 4) result += ")-" + digits.slice(4, 7);
+  if (digits.length >= 7) result += "-" + digits.slice(7, 9);
+  if (digits.length >= 9) result += "-" + digits.slice(9, 11);
+  return result;
 }


### PR DESCRIPTION
## Summary
- format phone numbers with parentheses
- add phone input mask helper
- apply input mask to callback forms
- apply input mask to header form

## Testing
- `npm test --silent -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_686404da54b88324ae584bb27ba3679d