### PR TITLE
Fix phone input mask clearing

### DIFF
--- a/src/utils/phone.js
+++ b/src/utils/phone.js
@@ -9,6 +9,7 @@ export function formatPhone(phone) {
 
 export function maskPhoneInput(value) {
   const digits = phoneDigits(value).slice(0, 11);
+  if (digits.length === 0) return "";
   let result = "+7";
   if (digits.length > 1) result += `-(${digits.slice(1, 4)}`;
   if (digits.length >= 4) result += ")-" + digits.slice(4, 7);


### PR DESCRIPTION
## Summary
- allow empty string return from `maskPhoneInput` so the phone number can be removed completely

## Testing
- `npm test --silent -- -w 1` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_686408596fc88324999260209ebc9bfc