### PR TITLE
Add name input in feedback forms

### DIFF
--- a/src/components/callback/callBack3.jsx
+++ b/src/components/callback/callBack3.jsx
@@ -16,7 +16,7 @@ function CallBackBottom() {
             To : 'dniwe.exe@ya.ru',
             From : "st1m2123@gmail.com",
             Subject : "Новый клиент",
-            Body : data.phone
+            Body : `Имя: ${data.name} Телефон: ${data.phone}`
         }).then(
           message => alert(message)
         );
@@ -55,6 +55,7 @@ function CallBackBottom() {
                                 </Text>
                                 <form onSubmit={handleSubmit(onSubmit)} className={styled.inputBlock}>
                                     <img src={RussianFlagIco} alt="" />
+                                    <input placeholder="Ваше имя" type="text" className={styled.nameInput} {...register('name', { required: true })} />
                                     <input placeholder="+7 (___) ___-__-__" type="text" className={styled.callbackInput} id="standard-basic" label="Телефон" variant="standard" {...register('phone', {
                             required: "Заполните поле с номером телефона", pattern: {
                                 value: /\d+/, 
@@ -119,6 +120,12 @@ function CallBackBottom() {
                     </Text>
                     <div className={styled.mobileInput}>
                         <img src={RussianFlagIco} alt="" />
+                        <input placeholder="Ваше имя" type="text" style={{
+                            borderRadius: "6px",
+                            border: "1px solid #2359C1",
+                            background: "#FFF",
+                            width: "130px"
+                        }} {...register('name', { required: true })} />
                         <input placeholder="+7 (___) ___-__-__" type="text" style={{
                             borderRadius: "6px",
                             border: "1px solid #2359C1",

--- a/src/components/callback/callback.module.css
+++ b/src/components/callback/callback.module.css
@@ -53,6 +53,15 @@
     background: #FFF;
     margin-right: 35px;
 }
+.nameInput {
+    width: 140px;
+    height: 35px;
+    flex-shrink: 0;
+    border-radius: 10px;
+    border: 1px solid #2359C1;
+    background: #FFF;
+    margin-right: 10px;
+}
 
 .inputBlock {
     display: flex;

--- a/src/components/callback/callback1.jsx
+++ b/src/components/callback/callback1.jsx
@@ -17,7 +17,7 @@ function CallBack1() {
             To : 'dniwe.exe@ya.ru',
             From : "st1m2123@gmail.com",
             Subject : "Новый клиент",
-            Body : data.phone
+            Body : `Имя: ${data.name} Телефон: ${data.phone}`
         }).then(
           message => alert(message)
         );
@@ -100,6 +100,7 @@ function CallBack1() {
                     }}>
                     <img src={FlagImg} alt="qwe" />
                     </Box>
+                    <input placeholder="Ваше имя" className={style.nameInput} type="text" {...register('name', { required: true })} />
                     <input placeholder="+7 (___) ___-__-__" className={style.input} type="text" id="standard-basic" label="Телефон" variant="standard" {...register('phone', {
                                 required: "Заполните поле с номером телефона", pattern: {
                                     value: /\d+/, 

--- a/src/components/callback/callback1.module.css
+++ b/src/components/callback/callback1.module.css
@@ -32,6 +32,15 @@
     flex-shrink: 0;
     margin-right: 25px;
 }
+.nameInput {
+    border-radius: 6px;
+    border: 1px solid #2359C1;
+    background: #FFF;
+    width: 140px;
+    height: 34px;
+    flex-shrink: 0;
+    margin-right: 10px;
+}
 .button{
     border-radius: 16px;
 background: #00ABE4;
@@ -75,6 +84,24 @@ line-height: normal;
     }
     
     .input {
+        border-radius: 6px;
+        border: 1px solid #2359C1;
+        background: #FFF;
+        width: 290px;
+        height: 38px;
+        flex-shrink: 0;
+        margin-right: 0;
+    }
+    .nameInput {
+        border-radius: 6px;
+        border: 1px solid #2359C1;
+        background: #FFF;
+        width: 290px;
+        height: 38px;
+        flex-shrink: 0;
+        margin-right: 0;
+    }
+    .nameInput {
         border-radius: 6px;
         border: 1px solid #2359C1;
         background: #FFF;

--- a/src/components/header/headerInfo.jsx
+++ b/src/components/header/headerInfo.jsx
@@ -31,7 +31,7 @@ function InfoHeader() {
             To: 'dniwe.exe@ya.ru',
             From: "st1m2123@gmail.com",
             Subject: "Новый клиент",
-            Body: data.phone
+            Body: `Имя: ${data.name} Телефон: ${data.phone}`
         }).then(
             message => alert(message)
         );
@@ -152,6 +152,12 @@ function InfoHeader() {
 
                         <form onSubmit={handleSubmit(onSubmit)} className={s.formSend}>
                             <div className={s.inputGroup}>
+                                <input
+                                    placeholder="Ваше имя"
+                                    className={s.inputStyle}
+                                    type="text"
+                                    {...register('name', { required: true })}
+                                />
                                 <div className={s.phoneInput}>
                                     <img src={RussianFlagIco} alt="Россия" className={s.flagIcon} />
                                     <input


### PR DESCRIPTION
## Summary
- allow users to enter their name in all callback forms
- include new field in emails sent from forms
- style new name inputs for desktop and mobile

## Testing
- `CI=true npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_686409f43d3c83249ffcb4ce3146e55d