### PR TITLE
Add admin password change feature

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -121,6 +121,20 @@ app.get('/api/me', authMiddleware, async (req, res) => {
   res.json(user);
 });
 
+// 🔄 Смена пароля
+app.put('/api/password', authMiddleware, async (req, res) => {
+  const { oldPassword = '', newPassword = '' } = req.body;
+  const user = await db.get('SELECT * FROM users WHERE id = ?', req.userId);
+  if (!user) return res.status(404).json({ message: 'User not found' });
+
+  const isValid = await bcrypt.compare(oldPassword, user.password);
+  if (!isValid) return res.status(400).json({ message: 'Wrong password' });
+
+  const hash = await bcrypt.hash(newPassword, 10);
+  await db.run('UPDATE users SET password = ? WHERE id = ?', hash, req.userId);
+  res.json({ message: 'Password updated' });
+});
+
 // ❓ Проверка наличия админа
 app.get('/api/admin-exists', async (req, res) => {
   const row = await db.get('SELECT 1 FROM users LIMIT 1');

--- a/src/components/adminPannel/ContentArea/index.jsx
+++ b/src/components/adminPannel/ContentArea/index.jsx
@@ -5,6 +5,7 @@ import { useParams } from "react-router-dom"
 import CardList from '../post/cardList'
 import EditPost from "../post/edit"
 import EditPhone from "../phone/edit"
+import EditPassword from "../password/edit"
 import { Typography } from "@mui/material"
 
 function ContentArea() {
@@ -29,6 +30,13 @@ function ContentArea() {
             return (
                 <div className={style.areaBox}>
                     <EditPhone/>
+                </div>
+            )
+        }
+        if (params == 'password') {
+            return (
+                <div className={style.areaBox}>
+                    <EditPassword/>
                 </div>
             )
         }
@@ -68,5 +76,4 @@ function ContentArea() {
         </div>
     )
 }
-
 export default ContentArea

--- a/src/components/adminPannel/menu/index.jsx
+++ b/src/components/adminPannel/menu/index.jsx
@@ -72,7 +72,17 @@ const btnData = [
         btn: [
             {
                 ImageUrl: Party,
-                btnName: "Изменить описание и фото" 
+                btnName: "Изменить описание и фото"
+            },
+        ]
+    },
+    {
+        menuTitle: "Управление аккаунтом:",
+        btn: [
+            {
+                ImageUrl: Direction,
+                btnName: "Сменить пароль",
+                linkTo: '/admin/password'
             },
         ]
     },
@@ -116,5 +126,4 @@ function Menu() {
         })}
         </div>
     )
-}
-export default Menu
+}export default Menu

--- a/src/components/adminPannel/password/edit.jsx
+++ b/src/components/adminPannel/password/edit.jsx
@@ -1,0 +1,59 @@
+import React, { useState } from "react";
+import { useDispatch } from "react-redux";
+import { changePassword } from "../../../redux/slices/auth";
+import { TextField, Button, Typography } from "@mui/material";
+import style from "./style.module.css";
+
+function EditPassword() {
+  const dispatch = useDispatch();
+  const [oldPassword, setOldPassword] = useState('');
+  const [newPassword, setNewPassword] = useState('');
+
+  const onSave = async () => {
+    const { error } = await dispatch(changePassword({ oldPassword, newPassword }));
+    if (!error) {
+      setOldPassword('');
+      setNewPassword('');
+      alert('Пароль обновлён');
+    } else {
+      alert('Не удалось изменить пароль');
+    }
+  };
+
+  return (
+    <div>
+      <Typography
+        sx={{
+          fontFamily: "SourceCodePro-SemiBold",
+          fontSize: "24px",
+          textAlign: "center",
+          marginTop: "27px",
+          marginBottom: "20px",
+        }}
+      >
+        Сменить пароль
+      </Typography>
+      <TextField
+        className={style.input}
+        value={oldPassword}
+        onChange={(e) => setOldPassword(e.target.value)}
+        label="Старый пароль"
+        type="password"
+        variant="outlined"
+      />
+      <TextField
+        className={style.input}
+        value={newPassword}
+        onChange={(e) => setNewPassword(e.target.value)}
+        label="Новый пароль"
+        type="password"
+        variant="outlined"
+      />
+      <Button variant="contained" onClick={onSave}>
+        Сохранить
+      </Button>
+    </div>
+  );
+}
+
+export default EditPassword;

--- a/src/components/adminPannel/password/style.module.css
+++ b/src/components/adminPannel/password/style.module.css
@@ -1,0 +1,4 @@
+.input {
+  padding: 10px;
+  margin-bottom: 20px;
+}

--- a/src/redux/slices/auth.js
+++ b/src/redux/slices/auth.js
@@ -16,6 +16,11 @@ export const fetchRegister = createAsyncThunk('auth/fetchRegister' ,  async (par
     return data
 })
 
+export const changePassword = createAsyncThunk('auth/changePassword', async (params) => {
+    const { data } = await axios.put('/password', params)
+    return data
+})
+
 
 const initialState = {
     data: null,
@@ -85,6 +90,18 @@ const authSlice = createSlice({
         builder.addCase(fetchRegister.rejected, (state) => { // rejected - если ошибка
             state.status = 'error';
             state.data = null;
+        });
+
+        builder.addCase(changePassword.pending, (state) => {
+            state.status = 'loading';
+        });
+
+        builder.addCase(changePassword.fulfilled, (state) => {
+            state.status = 'loaded';
+        });
+
+        builder.addCase(changePassword.rejected, (state) => {
+            state.status = 'error';
         });
     }
 })


### PR DESCRIPTION
## Summary
- add API route for password update
- support password change in auth slice
- provide UI to change password
- show password option in admin menu

## Testing
- `CI=true npm test --silent -- -u` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_686eafef8458832493692446f059e01a