### PR TITLE
Fix skeleton component import

### DIFF
--- a/src/components/adminPanel/Post/cardList.jsx
+++ b/src/components/adminPanel/Post/cardList.jsx
@@ -4,7 +4,7 @@ import CardPost from "./cardPost";
 import { Typography, Grid, Button } from '@mui/material';
 import { useDispatch, useSelector } from 'react-redux';
 import { fetchPosts } from '../../../redux/slices/posts';
-import PostLoading from '../skeleton/skeleton';
+import PostLoading from '../Skeleton/skeleton';
 import { Add } from '@mui/icons-material';
 import { motion } from 'framer-motion';
 


### PR DESCRIPTION
## Summary
- fix incorrect case in skeleton component import path

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ec061676483248fc07ffba36430ce