### PR TITLE
Enhance markdown experience

### DIFF
--- a/src/components/adminPanel/FullPost/index.jsx
+++ b/src/components/adminPanel/FullPost/index.jsx
@@ -3,6 +3,8 @@ import axios from "../../../axios/axios";
 import { useParams } from "react-router-dom";
 import { Typography, Box, CircularProgress, Container } from "@mui/material";
 import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+import rehypeRaw from 'rehype-raw';
 import { ElectricBolt, ErrorOutline } from "@mui/icons-material";
 import style from "./style.module.css";
 
@@ -93,7 +95,10 @@ function FullPost() {
 
                 <Box className={style.markdownContainer}>
                     <ReactMarkdown
+                        className={style.markdown}
                         children={postData.text}
+                        remarkPlugins={[remarkGfm]}
+                        rehypePlugins={[rehypeRaw]}
                         components={{
                             img: ({ node, ...props }) => (
                                 <img {...props} style={{ maxWidth: '100%', borderRadius: '8px' }} alt="" />

--- a/src/components/adminPanel/FullPost/style.module.css
+++ b/src/components/adminPanel/FullPost/style.module.css
@@ -112,6 +112,26 @@
     margin-bottom: 1rem !important;
 }
 
+.markdown {
+    font-family: 'Inter', sans-serif;
+    font-size: 16px;
+    line-height: 1.6;
+    color: #1a202c;
+    word-break: break-word;
+}
+
+.markdown ul {
+    margin-left: 20px;
+    list-style-type: disc;
+}
+
+.markdown code {
+    background-color: #f4f4f4;
+    padding: 2px 4px;
+    border-radius: 4px;
+    font-family: "Source Code Pro", monospace;
+}
+
 @media (max-width: 768px) {
     .postContainer {
         padding: 1rem;
@@ -123,5 +143,4 @@
 
     .postDescription {
         font-size: 1rem !important;
-    }
-}
+    }}

--- a/src/components/adminPanel/Post/edit.jsx
+++ b/src/components/adminPanel/Post/edit.jsx
@@ -278,6 +278,11 @@ const EditPost = () => {
           value={text}
           onChange={setText}
           height={500}
+          preview="live"
+          visibleDragbar={false}
+          textareaProps={{
+            placeholder: 'Введите текст поста...'
+          }}
           className={style.editor}
         />
       </Paper>


### PR DESCRIPTION
## Summary
- enable live preview in post editor
- show posts with GFM features
- style markdown output for better readability

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ed24340248324ae86c54b5e3a68af