### PR TITLE
Fix image upload limit

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -31,7 +31,11 @@ const storage = multer.diskStorage({
   }
 });
 
-const upload = multer({ storage });
+// Increase the default file size limit to 50MB to allow large image uploads
+const upload = multer({
+  storage,
+  limits: { fileSize: 50 * 1024 * 1024 },
+});
 
 app.use(express.json());
 app.use('/uploads', express.static(path.join(__dirname, 'uploads')));


### PR DESCRIPTION
## Summary
- allow larger file uploads on the server

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_686eee49b8148324812138ab21621226