### PR TITLE
Fix markdown editor width issue

### DIFF
--- a/src/components/adminPanel/Post/edit.module.css
+++ b/src/components/adminPanel/Post/edit.module.css
@@ -112,6 +112,17 @@
 
 .editor {
     margin-top: 1rem;
+    width: 100%;
+}
+
+/* Prevent the markdown editor from growing horizontally when typing */
+.editor :global(.w-md-editor) {
+    width: 100% !important;
+}
+
+.editor :global(textarea) {
+    white-space: pre-wrap;
+    word-break: break-word;
 }
 
 .galleryControls {


### PR DESCRIPTION
## Summary
- prevent markdown editor from expanding horizontally when typing

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f07c1a0b483248a1f5a832380ceef