### PR TITLE
Add responsive admin panel menu

### DIFF
--- a/src/components/adminPanel/AdminLayout.jsx
+++ b/src/components/adminPanel/AdminLayout.jsx
@@ -4,14 +4,15 @@ import { UserIsAuth } from "./Auth";
 import ContentArea from "./ContentArea";
 import style from "./AdminLayout.module.css";
 
-function AdminLayout() {
+function AdminLayout({ isMenuOpen, toggleMenu }) {
     return (
         <div className={style.container}>
             <div>
                 <UserIsAuth />
-                <Menu />
+                <Menu isOpen={isMenuOpen} toggleMenu={toggleMenu} />
             </div>
             <ContentArea />
+            {isMenuOpen && <div className={style.overlay} onClick={toggleMenu}></div>}
         </div>
     );
 }

--- a/src/components/adminPanel/AdminLayout.module.css
+++ b/src/components/adminPanel/AdminLayout.module.css
@@ -3,6 +3,24 @@
     /* gap: 10px; */
     justify-content: space-between;
     padding: 20px 0;
+    position: relative;
+}
+
+.overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: rgba(0,0,0,0.5);
+    z-index: 999;
+    display: none;
+}
+
+@media (max-width: 768px) {
+    .overlay {
+        display: block;
+    }
 }
 
 @media (max-width: 1024px) {

--- a/src/components/adminPanel/Button/index.jsx
+++ b/src/components/adminPanel/Button/index.jsx
@@ -3,7 +3,7 @@ import style from "./style.module.css";
 import { Typography } from "@mui/material";
 import { forwardRef } from "react";
 
-const Button = forwardRef(({ Icon, text, path, color = "#4e73df" }, ref) => {
+const Button = forwardRef(({ Icon, text, path, color = "#4e73df", onClick }, ref) => {
     const hoverColor = `${color}30`; // Добавляем прозрачность для hover эффекта
 
     return (
@@ -15,6 +15,7 @@ const Button = forwardRef(({ Icon, text, path, color = "#4e73df" }, ref) => {
                 '--hover-color': hoverColor,
             }}
             ref={ref}
+            onClick={onClick}
         >
             <div className={style.iconContainer}>
                 {Icon && <Icon className={style.btnIcon} />}

--- a/src/components/adminPanel/ContentArea/style.module.css
+++ b/src/components/adminPanel/ContentArea/style.module.css
@@ -16,6 +16,14 @@
     max-width: 850px;
 }
 
+@media (max-width: 850px) {
+    .contentContainer {
+        min-width: auto;
+        max-width: none;
+        width: 100%;
+    }
+}
+
 .welcomeContainer {
     display: flex;
     flex-direction: column;

--- a/src/components/adminPanel/Header/index.js
+++ b/src/components/adminPanel/Header/index.js
@@ -2,9 +2,9 @@ import style from "./style.module.css";
 import logo from '../images/logoAdmin.png';
 import { Typography } from "@mui/material";
 import { Link } from 'react-router-dom';
-import { ElectricBolt, ExitToApp } from "@mui/icons-material";
+import { ElectricBolt, ExitToApp, Menu as MenuIcon } from "@mui/icons-material";
 
-function Header() {
+function Header({ onMenuToggle }) {
     return (
         <header className={style.adminHeader}>
             <div className={style.headerContainer}>
@@ -23,7 +23,9 @@ function Header() {
                         </Typography>
                     </div>
                 </div>
-
+                <div className={style.burger} onClick={onMenuToggle}>
+                    <MenuIcon className={style.burgerIcon} />
+                </div>
                 <Link to="/" className={style.returnButton}>
                     <ExitToApp className={style.buttonIcon} />
                     <span>На сайт</span>

--- a/src/components/adminPanel/Header/style.module.css
+++ b/src/components/adminPanel/Header/style.module.css
@@ -109,3 +109,20 @@
     background: linear-gradient(90deg, transparent 0%, rgba(255, 255, 255, 0.1) 50%, transparent 100%);
     width: 100%;
 }
+
+.burger {
+    display: none;
+    cursor: pointer;
+    margin-right: 1rem;
+}
+
+.burgerIcon {
+    color: white;
+    font-size: 2rem !important;
+}
+
+@media (max-width: 768px) {
+    .burger {
+        display: block;
+    }
+}

--- a/src/components/adminPanel/Menu/index.jsx
+++ b/src/components/adminPanel/Menu/index.jsx
@@ -85,9 +85,9 @@ const btnData = [
     },
 ];
 
-function Menu() {
+function Menu({ isOpen, toggleMenu }) {
     return (
-        <div className={style.adminPanel}>
+        <div className={`${style.adminPanel} ${isOpen ? style.open : ''}`}>
             <div className={style.header}>
                 <ElectricBolt className={style.logoIcon} />
                 <Typography variant="h6" className={style.title}>
@@ -113,6 +113,7 @@ function Menu() {
                                     Icon={btn.Icon}
                                     text={btn.btnName}
                                     color={btn.color}
+                                    onClick={toggleMenu}
                                 />
                             ))}
                         </div>

--- a/src/components/adminPanel/Menu/style.module.css
+++ b/src/components/adminPanel/Menu/style.module.css
@@ -100,3 +100,20 @@
     color: rgba(255, 255, 255, 0.5);
     font-size: 0.8rem;
 }
+
+@media (max-width: 768px) {
+    .adminPanel {
+        top: 0;
+        left: 0;
+        width: 250px;
+        height: 100vh;
+        transform: translateX(-100%);
+        transition: transform 0.3s ease;
+        border-radius: 0;
+        z-index: 1000;
+    }
+
+    .adminPanel.open {
+        transform: translateX(0);
+    }
+}

--- a/src/pages/admin/admin.jsx
+++ b/src/pages/admin/admin.jsx
@@ -15,6 +15,9 @@ function AdminPanel() {
     const { status } = useSelector((state)=> state.auth);
     const isLoading = status === 'loading';
     const [exists, setExists] = React.useState(true);
+    const [menuOpen, setMenuOpen] = React.useState(false);
+
+    const toggleMenu = () => setMenuOpen(prev => !prev);
 
     React.useEffect(() => {
         dispatch(fetchAuthMe());
@@ -22,17 +25,17 @@ function AdminPanel() {
     }, []);
     return (
         <div className={style.background}>
-            <div className={style.layout}> 
-                <Header />
-               {isLoading ? (
-                   <Loading />
-               ) : isAuth ? (
-                   <AdminLayout />
-               ) : exists ? (
-                   <Auth />
-               ) : (
-                   <Register />
-               )}
+            <div className={style.layout}>
+                <Header onMenuToggle={toggleMenu} />
+                {isLoading ? (
+                    <Loading />
+                ) : isAuth ? (
+                    <AdminLayout isMenuOpen={menuOpen} toggleMenu={toggleMenu} />
+                ) : exists ? (
+                    <Auth />
+                ) : (
+                    <Register />
+                )}
             </div>
         </div>
     )


### PR DESCRIPTION
## Summary
- add menu toggling state in admin panel
- include hamburger button in admin header
- slide-out menu for mobile view
- close menu after navigation
- add overlay to dim background when menu open
- make content width responsive

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_687bf7dd11d883249801115f996d655a