### PR TITLE
Fix mobile admin menu

### DIFF
--- a/src/components/adminPanel/Auth/style.module.css
+++ b/src/components/adminPanel/Auth/style.module.css
@@ -69,7 +69,7 @@
     border-radius: 12px;
     padding: 12px 20px;
     box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
-    z-index: 1000;
+    z-index: 900;
 }
 
 .userInfo {
@@ -96,8 +96,9 @@
     }
 
     .userIsAuth {
-        top: 10px;
-        right: 10px;
+        position: static;
+        margin: 10px auto;
+        width: calc(100% - 20px);
         padding: 8px 12px;
     }
 

--- a/src/components/adminPanel/Header/style.module.css
+++ b/src/components/adminPanel/Header/style.module.css
@@ -3,7 +3,7 @@
     box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
     position: sticky;
     top: 0;
-    z-index: 1000;
+    z-index: 1100;
     padding: 0 2rem;
     border-radius: 15px;
 }
@@ -124,5 +124,11 @@
 @media (max-width: 768px) {
     .burger {
         display: block;
+    }
+}
+
+@media (max-width: 600px) {
+    .returnButton {
+        display: none;
     }
 }


### PR DESCRIPTION
## Summary
- bump header z-index so the burger icon stays visible
- hide return button on small screens
- reposition auth greeting on mobile to prevent layout break

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_687bfda25f248324a22537190ff2d949