### PR TITLE
Add mobile menu button

### DIFF
--- a/src/components/adminPanel/AdminLayout.jsx
+++ b/src/components/adminPanel/AdminLayout.jsx
@@ -2,6 +2,7 @@ import React from "react";
 import Menu from "./Menu";
 import { UserIsAuth } from "./Auth";
 import ContentArea from "./ContentArea";
+import MobileMenuButton from "./MobileMenuButton";
 import style from "./AdminLayout.module.css";
 
 function AdminLayout({ isMenuOpen, toggleMenu }) {
@@ -12,6 +13,7 @@ function AdminLayout({ isMenuOpen, toggleMenu }) {
                 <Menu isOpen={isMenuOpen} toggleMenu={toggleMenu} />
             </div>
             <ContentArea />
+            {!isMenuOpen && <MobileMenuButton onClick={toggleMenu} />}
             {isMenuOpen && <div className={style.overlay} onClick={toggleMenu}></div>}
         </div>
     );

--- a/src/components/adminPanel/MobileMenuButton/index.jsx
+++ b/src/components/adminPanel/MobileMenuButton/index.jsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { Fab } from '@mui/material';
+import MenuIcon from '@mui/icons-material/Menu';
+import style from './style.module.css';
+
+function MobileMenuButton({ onClick }) {
+    return (
+        <Fab className={style.fab} color="primary" onClick={onClick}>
+            <MenuIcon />
+        </Fab>
+    );
+}
+
+export default MobileMenuButton;

--- a/src/components/adminPanel/MobileMenuButton/style.module.css
+++ b/src/components/adminPanel/MobileMenuButton/style.module.css
@@ -1,0 +1,13 @@
+.fab {
+    position: fixed;
+    bottom: 20px;
+    right: 20px;
+    z-index: 1200;
+    display: none;
+}
+
+@media (max-width: 768px) {
+    .fab {
+        display: flex;
+    }
+}

--- a/src/components/adminPanel/index.js
+++ b/src/components/adminPanel/index.js
@@ -3,3 +3,4 @@ export { default as Auth } from './Auth';
 export { default as Register } from './Register';
 export { default as AdminLayout } from './AdminLayout';
 export { default as Loading } from './Loading/loading';
+export { default as MobileMenuButton } from './MobileMenuButton';


### PR DESCRIPTION
## Summary
- add floating button to toggle admin panel menu
- export mobile button component

## Testing
- `npm install` *(fails: internet is disabled)*
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68818307a0b48324929fd73fbbbfbf8a