### PR TITLE
Improve mobile admin menu overlay

### DIFF
--- a/src/components/adminPanel/AdminLayout.module.css
+++ b/src/components/adminPanel/AdminLayout.module.css
@@ -13,7 +13,7 @@
     width: 100%;
     height: 100%;
     background: rgba(0,0,0,0.5);
-    z-index: 999;
+    z-index: 1200;
     display: none;
 }
 

--- a/src/components/adminPanel/Menu/style.module.css
+++ b/src/components/adminPanel/Menu/style.module.css
@@ -11,6 +11,7 @@
     flex-direction: column;
     color: white;
     overflow-y: auto;
+    z-index: 1300;
 }
 
 .header {
@@ -110,7 +111,7 @@
         transform: translateX(-100%);
         transition: transform 0.3s ease;
         border-radius: 0;
-        z-index: 1000;
+        z-index: 1300;
     }
 
     .adminPanel.open {

--- a/src/components/adminPanel/MobileMenuButton/style.module.css
+++ b/src/components/adminPanel/MobileMenuButton/style.module.css
@@ -1,8 +1,8 @@
 .fab {
     position: fixed;
     bottom: 20px;
-    right: 20px;
-    z-index: 1200;
+    left: 20px;
+    z-index: 1300;
     display: none;
 }
 


### PR DESCRIPTION
## Summary
- fix menu overlay z-index so it covers page content on mobile
- move floating menu button to bottom-left
- raise menu button z-index

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6881859da91c8324a3bcf20e50f79125