### PR TITLE
Fix default API endpoint port

### DIFF
--- a/src/axios/axios.js
+++ b/src/axios/axios.js
@@ -1,6 +1,7 @@
 import axios from 'axios';
 
-const RAW_URL = process.env.REACT_APP_API_URL || 'http://localhost:4000/api';
+// Use backend port 3001 by default to match the server configuration
+const RAW_URL = process.env.REACT_APP_API_URL || 'http://localhost:3001/api';
 
 const API_URL = RAW_URL.endsWith('/api')
   ? RAW_URL


### PR DESCRIPTION
## Summary
- point axios defaults to the correct backend port

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688d1290c67c8324a2e2680daee95511