### PR TITLE
Add home button to admin menu

### DIFF
--- a/src/components/adminPanel/Menu/index.jsx
+++ b/src/components/adminPanel/Menu/index.jsx
@@ -1,7 +1,7 @@
 import style from "./style.module.css";
 import Button from "../Button";
 import { Typography } from "@mui/material";
-import { ElectricBolt, Edit, Add, Reviews, Contacts, Construction, Settings, AccountCircle, ArrowDownward } from "@mui/icons-material";
+import { ElectricBolt, Edit, Add, Reviews, Contacts, Construction, Settings, AccountCircle, ArrowDownward, Home } from "@mui/icons-material";
 
 const btnData = [
     {
@@ -120,8 +120,14 @@ function Menu({ isOpen, toggleMenu }) {
                     </div>
                 ))}
             </div>
-
             <div className={style.footer}>
+                <Button
+                    path="/"
+                    Icon={Home}
+                    text="Перейти на главную страницу"
+                    color="#FF5722"
+                    onClick={toggleMenu}
+                />
                 <Typography variant="caption">
                     © {new Date().getFullYear()} Электромонтаж
                 </Typography>

--- a/src/components/adminPanel/Menu/style.module.css
+++ b/src/components/adminPanel/Menu/style.module.css
@@ -101,6 +101,10 @@
     margin-top: auto;
     color: rgba(255, 255, 255, 0.5);
     font-size: 0.8rem;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    align-items: center;
 }
 
 @media (max-width: 768px) {


### PR DESCRIPTION
## Summary
- import Home icon
- display a button linking to the main page at the bottom of admin menu
- style footer to layout button

## Testing
- `CI=true npm test -- -u` *(fails: SyntaxError in axios)*

------
https://chatgpt.com/codex/tasks/task_e_688d348109388324b9cd8292312070ad