### PR TITLE
Fix page reload in admin navigation

### DIFF
--- a/src/components/adminPanel/Post/cardList.jsx
+++ b/src/components/adminPanel/Post/cardList.jsx
@@ -3,6 +3,7 @@ import { useEffect } from 'react';
 import CardPost from "./cardPost";
 import { Typography, Grid, Button, useMediaQuery, useTheme } from '@mui/material';
 import { useDispatch, useSelector } from 'react-redux';
+import { Link as RouterLink } from 'react-router-dom';
 import { fetchPosts } from '../../../redux/slices/posts';
 import PostLoading from '../Skeleton/skeleton';
 import { Add } from '@mui/icons-material';
@@ -35,7 +36,8 @@ function CardList() {
                         variant="contained"
                         startIcon={<Add />}
                         className={style.createButton}
-                        href="/admin/create"
+                        component={RouterLink}
+                        to="/admin/create"
                         sx={{
                             borderRadius: '12px',
                             textTransform: 'none',

--- a/src/components/header/appBar.jsx
+++ b/src/components/header/appBar.jsx
@@ -47,7 +47,7 @@ function NavBar() {
           Контакты
         </NavDropdown.Item>
         <NavDropdown.Divider />
-        <NavDropdown.Item href="/admin">Админ панель</NavDropdown.Item>
+        <NavDropdown.Item as={Link} to="/admin">Админ панель</NavDropdown.Item>
       </NavDropdown>
     </div>
   )


### PR DESCRIPTION
## Summary
- prevent full page reload when creating posts
- avoid reload when opening admin panel from dropdown

## Testing
- `npm test -- --watchAll=false` *(fails: Jest encountered an unexpected token)*

------
https://chatgpt.com/codex/tasks/task_e_688d4f5e93388324ad034c468e8c20e0