### PR TITLE
Fix missing useState import in WorkExamples

### DIFF
--- a/src/components/workExamples/workExamples.jsx
+++ b/src/components/workExamples/workExamples.jsx
@@ -1,7 +1,7 @@
 import { useSelector } from "react-redux";
 import turnOnImg from "./img/switch.png";
 import WebFont from 'webfontloader';
-import { useContext, useEffect, useRef } from "react";
+import { useContext, useEffect, useRef, useState } from "react";
 import AliceCarousel from 'react-alice-carousel';
 import 'react-alice-carousel/lib/alice-carousel.css';
 import { Box, IconButton } from "@mui/material";


### PR DESCRIPTION
## Summary
- add the missing useState import used by the WorkExamples gallery component

## Testing
- npm test --watchAll=false
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e569315e50832aaef19335813c19fe